### PR TITLE
Adds `--exit-zero` option to pylint CI script

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-## Linter
-
-pipenv run python -m pylint src/main/python/ttconv/ src/test/python/
-
 # Exit immediately if unit tests exit with a non-zero status.
 set -e
+
+## Linter
+
+pipenv run python -m pylint --exit-zero src/main/python/ttconv/ src/test/python/
 
 ## unit test and coverage
 


### PR DESCRIPTION
Closes #166

>  If the option is specified, and Pylint runs successfully, it will exit with 0 regardless of the number of lint issues detected. Configuration errors, parse errors, and calling Pylint with invalid command-line options all still return a non-zero error code, even if --exit-zero is specified.