### PR TITLE
Add support webvtt color

### DIFF
--- a/src/main/python/ttconv/vtt/css_class.py
+++ b/src/main/python/ttconv/vtt/css_class.py
@@ -1,0 +1,17 @@
+"""CSS class"""
+
+class CssClass:
+  """CSS class definition class"""
+
+  def __init__(self, property_name: str, value: str, classname: str):
+    self._propertyname = property_name
+    self._classname = classname
+    self._value = value
+
+  def to_string(self) -> str:
+    """Return CSS class as formated string"""
+    return str(self)
+
+  def __str__(self) -> str:
+    return "\n".join(("video::cue(.{}):".format(self._classname),
+                     "{", "  {}: {}".format(self._propertyname, self._value), "}"))

--- a/src/main/python/ttconv/vtt/css_class.py
+++ b/src/main/python/ttconv/vtt/css_class.py
@@ -13,5 +13,5 @@ class CssClass:
     return str(self)
 
   def __str__(self) -> str:
-    return "\n".join(("video::cue(.{}):".format(self._classname),
-                     "{", "  {}: {}".format(self._propertyname, self._value), "}"))
+    return "\n".join(("::cue(.{}) {{".format(self._classname),
+                      "  {}: {};".format(self._propertyname, self._value), "}"))

--- a/src/main/python/ttconv/vtt/style.py
+++ b/src/main/python/ttconv/vtt/style.py
@@ -25,7 +25,7 @@
 
 """VTT style"""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from ttconv.model import ContentElement
 from ttconv.style_properties import FontWeightType, StyleProperties, FontStyleType, TextDecorationType
@@ -39,9 +39,33 @@ ITALIC_TAG_OUT = "</i>"
 UNDERLINE_TAG_IN = "<u>"
 UNDERLINE_TAG_OUT = "</u>"
 
-FONT_COLOR_TAG_IN = "<font color=\"{}\">"
-FONT_COLOR_TAG_OUT = "</font>"
+COLOR_TAG_IN = "<c.{}>"
+COLOR_TAG_OUT = "</c>"
 
+BG_COLOR_TAG_IN = "<c.{}>"
+BG_COLOR_TAG_OUT = "</c>"
+
+DEFAULT_TEXT_COLORS: Dict[str, str] = {
+  "#ffffffff": "white",
+  "#00ff00ff": "lime",
+  "#00ffffff": "cyan",
+  "#ff0000ff": "red",
+  "#ffff00ff": "yellow",
+  "#ff00ffff": "magenta",
+  "#0000ffff": "blue",
+  "#000000ff": "black"
+}
+
+DEFAULT_BACKGROUND_COLORS: Dict[str, str] = {
+  "#ffffffff": "bg_white",
+  "#00ff00ff": "bg_lime",
+  "#00ffffff": "bg_cyan",
+  "#ff0000ff": "bg_red",
+  "#ffff00ff": "bg_yellow",
+  "#ff00ffff": "bg_magenta",
+  "#0000ffff": "bg_blue",
+  "#000000ff": "bg_black"
+}
 
 def is_element_bold(element: ContentElement) -> bool:
   """Returns whether the element text is bold"""
@@ -61,12 +85,45 @@ def is_element_underlined(element: ContentElement) -> bool:
   return text_decoration is not None and text_decoration.underline is True
 
 
-def get_font_color(element: ContentElement) -> Optional[str]:
-  """Returns the font color code if present"""
-  font_color = element.get_style(StyleProperties.Color)
+def get_color(element: ContentElement) -> Optional[str]:
+  """Returns the text color hex code if present"""
+  color = element.get_style(StyleProperties.Color)
 
-  if font_color is None:
+  if color is None:
     return None
 
-  (r, g, b, a) = font_color.components
+  (r, g, b, a) = color.components
   return "#{:02x}{:02x}{:02x}{:02x}".format(r, g, b, a)
+
+def get_background_color(element: ContentElement) -> Optional[str]:
+  """Returns the background color hex code"""
+  background_color = element.get_style(StyleProperties.BackgroundColor)
+  
+  if background_color is None:
+    return "#00000000" # default to transparent background
+
+  (r, g, b, a) = background_color.components
+  return "#{:02x}{:02x}{:02x}{:02x}".format(r, g, b, a)
+
+
+def get_color_classname(color_value: str):
+  """Returns CSS color classname"""
+
+  if color_value is None:
+    return None
+
+  if DEFAULT_TEXT_COLORS.get(color_value) is not None:
+    return DEFAULT_TEXT_COLORS.get(color_value)
+
+  return f'fg_color_{color_value[1:]}'
+
+def get_background_color_classname(color_value: str):
+  """Returns CSS background color classname"""
+
+  if color_value is None:
+    return None
+
+  if DEFAULT_BACKGROUND_COLORS.get(color_value) is not None:
+    return DEFAULT_BACKGROUND_COLORS.get(color_value)
+
+  return f'bg_color_{color_value[1:]}'

--- a/src/main/python/ttconv/vtt/style.py
+++ b/src/main/python/ttconv/vtt/style.py
@@ -100,17 +100,14 @@ def get_background_color(element: ContentElement) -> Optional[str]:
   background_color = element.get_style(StyleProperties.BackgroundColor)
   
   if background_color is None:
-    return "#00000000" # default to transparent background
+    return None
 
   (r, g, b, a) = background_color.components
   return "#{:02x}{:02x}{:02x}{:02x}".format(r, g, b, a)
-
+  
 
 def get_color_classname(color_value: str):
   """Returns CSS color classname"""
-
-  if color_value is None:
-    return None
 
   if DEFAULT_TEXT_COLORS.get(color_value) is not None:
     return DEFAULT_TEXT_COLORS.get(color_value)
@@ -119,9 +116,6 @@ def get_color_classname(color_value: str):
 
 def get_background_color_classname(color_value: str):
   """Returns CSS background color classname"""
-
-  if color_value is None:
-    return None
 
   if DEFAULT_BACKGROUND_COLORS.get(color_value) is not None:
     return DEFAULT_BACKGROUND_COLORS.get(color_value)

--- a/src/main/python/ttconv/vtt/writer.py
+++ b/src/main/python/ttconv/vtt/writer.py
@@ -27,7 +27,7 @@
 
 import logging
 from fractions import Fraction
-from typing import List
+from typing import Dict, List
 
 import ttconv.model as model
 import ttconv.vtt.style as style
@@ -38,6 +38,7 @@ from ttconv.filters.merge_regions import RegionsMergingFilter
 from ttconv.filters.supported_style_properties import SupportedStylePropertiesFilter
 from ttconv.isd import ISD
 from ttconv.vtt.paragraph import VttParagraph
+from ttconv.vtt.css_class import CssClass
 from ttconv.style_properties import StyleProperties, FontStyleType, NamedColors, FontWeightType, TextDecorationType
 
 LOGGER = logging.getLogger(__name__)
@@ -63,6 +64,9 @@ class VttContext:
       StyleProperties.Color: [
         # Every values
       ],
+      StyleProperties.BackgroundColor: [
+        # Every values
+      ],
     }),
     DefaultStylePropertyValuesFilter({
       StyleProperties.Color: NamedColors.white.value,
@@ -76,6 +80,9 @@ class VttContext:
     self._begin: Fraction = Fraction(0)
     self._end: Fraction = Fraction(0)
     self._paragraphs: List[VttParagraph] = []
+    self._css_classes: List[CssClass] = []
+    self._colors_used: Dict[str, str] = {}
+    self._background_colors_used: Dict[str, str] = {}
 
   def append_element(self, element: model.ContentElement, offset: Fraction):
     """Converts model element to VTT content"""
@@ -101,10 +108,26 @@ class VttContext:
       is_bold = style.is_element_bold(element)
       is_italic = style.is_element_italic(element)
       is_underlined = style.is_element_underlined(element)
-      font_color = style.get_font_color(element)
+      color = style.get_color(element)
+      bg_color = style.get_background_color(element)
 
-      if font_color is not None:
-        self._paragraphs[-1].append_text(style.FONT_COLOR_TAG_IN.format(font_color))
+      if color is not None:
+        if self._colors_used.get(color) is None:
+          color_classname = style.get_color_classname(color)
+          self._colors_used[color] = color_classname
+          self._css_classes.append(CssClass("color", color, color_classname))
+        else:
+          color_classname = self._colors_used[color]
+        self._paragraphs[-1].append_text(style.COLOR_TAG_IN.format(color_classname))
+
+      if bg_color is not None:
+        if self._background_colors_used.get(bg_color) is None:
+          bg_color_classname = style.get_background_color_classname(bg_color)
+          self._background_colors_used[bg_color] = bg_color_classname
+          self._css_classes.append(CssClass("background-color", bg_color, bg_color_classname))
+        else:
+          bg_color_classname = self._background_colors_used[bg_color]
+        self._paragraphs[-1].append_text(style.BG_COLOR_TAG_IN.format(bg_color_classname))
 
       if is_bold:
         self._paragraphs[-1].append_text(style.BOLD_TAG_IN)
@@ -122,8 +145,11 @@ class VttContext:
         self._paragraphs[-1].append_text(style.ITALIC_TAG_OUT)
       if is_bold:
         self._paragraphs[-1].append_text(style.BOLD_TAG_OUT)
-      if font_color is not None:
-        self._paragraphs[-1].append_text(style.FONT_COLOR_TAG_OUT)
+      if color is not None:
+        self._paragraphs[-1].append_text(style.COLOR_TAG_OUT)
+      if bg_color is not None:
+        self._paragraphs[-1].append_text(style.BG_COLOR_TAG_OUT)
+
 
     if isinstance(element, model.Br):
       self._paragraphs[-1].append_text("\n")
@@ -165,8 +191,15 @@ class VttContext:
         LOGGER.warning("Set a default end value to paragraph (begin + 10s).")
         self._paragraphs[-1].set_end(self._paragraphs[-1].get_begin().to_seconds() + 10.0)
 
+  def style_block(self):
+    """Generated CSS INLINE STYLE Block"""
+    style_block = ""
+    if len(self._css_classes) > 0:
+      style_block = "STYLE\n" + "\n".join(css.to_string() for css in self._css_classes) + "\n\n"
+    return style_block
+
   def __str__(self) -> str:
-    return "WEBVTT\n\n" + "\n".join(p.to_string() for p in self._paragraphs)
+    return "WEBVTT\n\n" + self.style_block() + "\n".join(p.to_string() for p in self._paragraphs)
 
 
 #

--- a/src/main/python/ttconv/vtt/writer.py
+++ b/src/main/python/ttconv/vtt/writer.py
@@ -70,6 +70,7 @@ class VttContext:
     }),
     DefaultStylePropertyValuesFilter({
       StyleProperties.Color: NamedColors.white.value,
+      StyleProperties.BackgroundColor: NamedColors.transparent.value,
       StyleProperties.FontWeight: FontWeightType.normal,
       StyleProperties.FontStyle: FontStyleType.normal,
     })
@@ -194,8 +195,9 @@ class VttContext:
   def style_block(self):
     """Generated CSS INLINE STYLE Block"""
     style_block = ""
+    cue_default = "\n".join(("::cue {","  background-color: transparent;", "}\n"))
     if len(self._css_classes) > 0:
-      style_block = "STYLE\n" + "\n".join(css.to_string() for css in self._css_classes) + "\n\n"
+      style_block = "STYLE\n" + cue_default +"\n".join(css.to_string() for css in self._css_classes) + "\n\n"
     return style_block
 
   def __str__(self) -> str:


### PR DESCRIPTION
- Add code to translate text and background color from the model to VTT
  inline styling and default class names.

- Tests are still missing.
  