### PR TITLE
WebVTT writer: add support for line positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ Specifies a maximum number of rows for open subtitles, either the MNR field of t
 
 Default: `23`
 
+### VTT Writer configuration
+
+#### line_position
+
+`"line_position" : true | false`
+
+`true` means that the VTT writer outputs line and line alignment cue settings
+
+Default: `false`
+
 ### Library
 
 The overall architecture of the library is as follows:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ tt convert -i <input .scc file> -o <output .ttml file>
   * `"general": JSON object`: General configuration options (see below)
   * `"imsc_writer": JSON object`: IMSC Writer configuration options (see below)
   * `"stl_reader": JSON object`: STL Reader configuration options (see below)
+  * `"vtt_writer": JSON object`: WebVTT Writer configuration options (see below)
 
 Example:
 

--- a/src/main/python/ttconv/tt.py
+++ b/src/main/python/ttconv/tt.py
@@ -41,6 +41,7 @@ import ttconv.scc.reader as scc_reader
 import ttconv.srt.writer as srt_writer
 import ttconv.srt.reader as srt_reader
 import ttconv.stl.reader as stl_reader
+from ttconv.vtt.config import VTTWriterConfiguration
 import ttconv.vtt.writer as vtt_writer
 from ttconv.config import GeneralConfiguration
 from ttconv.config import ModuleConfiguration
@@ -380,9 +381,14 @@ def convert(args):
 
   elif writer_type is FileTypes.VTT:
     #
+    # Read the config
+    #
+    writer_config = read_config_from_json(VTTWriterConfiguration, json_config_data)
+
+    #
     # Construct and configure the writer
     #
-    vtt_document = vtt_writer.from_model(model, None, progress_callback_write)
+    vtt_document = vtt_writer.from_model(model, writer_config, progress_callback_write)
 
     #
     # Write out the converted file

--- a/src/main/python/ttconv/vtt/config.py
+++ b/src/main/python/ttconv/vtt/config.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+# Copyright (c) 2020, Sandflow Consulting LLC
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""WebVTT configuration"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from ttconv.config import ModuleConfiguration
+
+@dataclass
+class VTTWriterConfiguration(ModuleConfiguration):
+  """VTT writer configuration"""
+  
+  @classmethod
+  def name(cls):
+    return "vtt_writer"
+
+  # outputs `line` and `line alignment` cue settings
+  line_position: bool = field(default=False, metadata={"decoder": bool})

--- a/src/main/python/ttconv/vtt/cue.py
+++ b/src/main/python/ttconv/vtt/cue.py
@@ -25,16 +25,22 @@
 
 """WebVTT paragraph"""
 
+from enum import Enum
 import re
 from fractions import Fraction
 from typing import Optional, Union
-from ttconv.style_properties import DisplayAlignType
 
 from ttconv.time_code import ClockTime
 
 
 class VttCue:
   """VTT cue class"""
+
+  class LineAlignment(Enum):
+    """WebVTT line alignment cue setting"""
+    start = "start"
+    center = "center"
+    end = "end"
 
   _EOL_SEQ_RE = re.compile(r"\n{2,}")
 
@@ -44,7 +50,7 @@ class VttCue:
     self._end: Optional[ClockTime] = None
     self._text: str = ""
     self._line: int = None
-    self._align: DisplayAlignType = None
+    self._align: VttCue.LineAlignment = None
 
   def set_begin(self, offset: Fraction):
     """Sets the paragraph begin time code"""
@@ -68,18 +74,18 @@ class VttCue:
     return self._end
 
   def set_line(self, line: int):
-    """Sets the WebVTT line cue setting"""
+    """Sets the WebVTT line cue setting (in whole percent)"""
     self._line = line
 
   def get_line(self) -> Optional[int]:
-    """Return the WebVTT line cue setting"""
+    """Return the WebVTT line cue setting (in whole percent)"""
     return self._line
 
-  def set_align(self, align: DisplayAlignType):
+  def set_align(self, align: LineAlignment):
     """Sets the WebVTT line alignment cue setting"""
     self._align = align
 
-  def get_align(self) -> Optional[DisplayAlignType]:
+  def get_align(self) -> Optional[LineAlignment]:
     """Return the WebVTT line alignment cue setting"""
     return self._align
 

--- a/src/main/python/ttconv/vtt/cue.py
+++ b/src/main/python/ttconv/vtt/cue.py
@@ -28,12 +28,13 @@
 import re
 from fractions import Fraction
 from typing import Optional, Union
+from ttconv.style_properties import DisplayAlignType
 
 from ttconv.time_code import ClockTime
 
 
-class VttParagraph:
-  """VTT paragraph definition class"""
+class VttCue:
+  """VTT cue class"""
 
   _EOL_SEQ_RE = re.compile(r"\n{2,}")
 
@@ -42,6 +43,8 @@ class VttParagraph:
     self._begin: Optional[ClockTime] = None
     self._end: Optional[ClockTime] = None
     self._text: str = ""
+    self._line: int = None
+    self._align: DisplayAlignType = None
 
   def set_begin(self, offset: Fraction):
     """Sets the paragraph begin time code"""
@@ -64,6 +67,22 @@ class VttParagraph:
     """Returns the paragraph end time code"""
     return self._end
 
+  def set_line(self, line: int):
+    """Sets the WebVTT line cue setting"""
+    self._line = line
+
+  def get_line(self) -> Optional[int]:
+    """Return the WebVTT line cue setting"""
+    return self._line
+
+  def set_align(self, align: DisplayAlignType):
+    """Sets the WebVTT line alignment cue setting"""
+    self._align = align
+
+  def get_align(self) -> Optional[DisplayAlignType]:
+    """Return the WebVTT line alignment cue setting"""
+    return self._align
+
   def is_only_whitespace_or_empty(self):
     """Returns whether the paragraph text contains only whitespace or is empty"""
     return len(self._text) == 0 or self._text.isspace()
@@ -71,7 +90,7 @@ class VttParagraph:
   def normalize_eol(self):
     """Remove line breaks at the beginning and end of the paragraph, and replace
     line break sequences with a single line break"""
-    self._text = VttParagraph._EOL_SEQ_RE.sub("\n", self._text).strip("\n\r")
+    self._text = VttCue._EOL_SEQ_RE.sub("\n", self._text).strip("\n\r")
 
   def append_text(self, text: str):
     """Appends text to the paragraph"""
@@ -91,5 +110,24 @@ class VttParagraph:
     return str(self)
 
   def __str__(self) -> str:
-    return "\n".join((str(self._id), str(self._begin) + " --> " + str(self._end), str(self._text))) \
-           + ("\n" if self._text else "")
+
+    # cue identifier
+    t = f"{self._id}\n"
+    
+    # cue timing
+    t += f"{self._begin} --> {self._end}"
+
+    # cue line position
+    if self._line is not None:
+      t += f" line:{self._line}%"
+
+      if self._align is not None:
+        t += f",{self._align.value}"
+
+    t += "\n"
+
+    # cue body
+    if self._text:
+      t += self._text + "\n"
+
+    return t

--- a/src/test/python/test_vtt_cue.py
+++ b/src/test/python/test_vtt_cue.py
@@ -33,7 +33,7 @@ import unittest
 from ttconv.vtt.cue import VttCue
 
 
-class VttParagraphTest(unittest.TestCase):
+class VttCueTest(unittest.TestCase):
 
   def test_paragraph(self):
     paragraph = VttCue(123)

--- a/src/test/python/test_vtt_paragraph.py
+++ b/src/test/python/test_vtt_paragraph.py
@@ -30,13 +30,13 @@
 from fractions import Fraction
 import unittest
 
-from ttconv.vtt.paragraph import VttParagraph
+from ttconv.vtt.cue import VttCue
 
 
 class VttParagraphTest(unittest.TestCase):
 
   def test_paragraph(self):
-    paragraph = VttParagraph(123)
+    paragraph = VttCue(123)
 
     self.assertRaisesRegex(ValueError, "VTT paragraph begin time code must be set.", paragraph.to_string)
 

--- a/src/test/python/test_vtt_writer.py
+++ b/src/test/python/test_vtt_writer.py
@@ -27,6 +27,7 @@
 
 # pylint: disable=R0201,C0115,C0116,W0212
 
+import json
 import os
 import unittest
 import xml.etree.ElementTree as et
@@ -142,6 +143,10 @@ Cool, got it, will do it by end of next week.
     model = imsc_reader.to_model(et.ElementTree(et.fromstring(ttml_doc_str)))
     config = VTTWriterConfiguration()
     config.line_position = True
+    vtt_from_model = vtt_writer.from_model(model, config)
+    self.assertEqual(expected_vtt, vtt_from_model)
+
+    config = VTTWriterConfiguration.parse(json.loads('{"line_position":true}'))
     vtt_from_model = vtt_writer.from_model(model, config)
     self.assertEqual(expected_vtt, vtt_from_model)
 

--- a/src/test/python/test_vtt_writer.py
+++ b/src/test/python/test_vtt_writer.py
@@ -36,6 +36,7 @@ from pathlib import Path
 import ttconv.imsc.reader as imsc_reader
 import ttconv.scc.reader as scc_reader
 import ttconv.stl.reader as stl_reader
+from ttconv.vtt.config import VTTWriterConfiguration
 import ttconv.vtt.writer as vtt_writer
 from ttconv.model import ContentDocument, Region, Body, Div, P, Span, Text, ContentElement
 from ttconv.style_properties import StyleProperties, DisplayType
@@ -139,7 +140,9 @@ Cool, got it, will do it by end of next week.
 """
 
     model = imsc_reader.to_model(et.ElementTree(et.fromstring(ttml_doc_str)))
-    vtt_from_model = vtt_writer.from_model(model, None)
+    config = VTTWriterConfiguration()
+    config.line_position = True
+    vtt_from_model = vtt_writer.from_model(model, config)
     self.assertEqual(expected_vtt, vtt_from_model)
 
   def test_scc_test_suite(self):

--- a/src/test/python/test_vtt_writer.py
+++ b/src/test/python/test_vtt_writer.py
@@ -106,6 +106,42 @@ Pellentesque interdum lacinia sollicitudin.
 
     self.assertEqual(expected_vtt, vtt_from_model)
 
+  def test_position(self):
+    ttml_doc_str = """<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en-US" xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" ttp:frameRate="24" ttp:frameRateMultiplier="1000 1001" ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/text" ttp:timeBase="media">
+  <head>
+    <styling>
+      <style xml:id="style.center" tts:fontFamily="Arial" tts:fontSize="100%" tts:fontStyle="normal" tts:fontWeight="normal" tts:backgroundColor="transparent" tts:color="white" tts:textAlign="center"/>
+    </styling>
+    <layout>
+      <region xml:id="region.after" tts:displayAlign="after" tts:backgroundColor="transparent" tts:origin="10% 10%" tts:extent="80% 80%"/>
+      <region xml:id="region.before" tts:displayAlign="before" tts:backgroundColor="transparent" tts:origin="10% 10%" tts:extent="80% 80%"/>
+    </layout>
+  </head>
+  <body>
+    <div>
+      <p style="style.center" region="region.after" begin="00:00:03:12" end="00:00:12:00">Only one or two short samples are needed<br/>to make sure the conversion basically works</p>
+      <p style="style.center" region="region.before" begin="00:00:14:09" end="00:00:25:17">Cool, got it, will do it by end of next week.</p>
+    </div>
+  </body>
+</tt>"""
+
+    expected_vtt="""WEBVTT
+
+1
+00:00:03.501 --> 00:00:12.000 line:90%,after
+Only one or two short samples are needed
+to make sure the conversion basically works
+
+2
+00:00:14.375 --> 00:00:25.709 line:10%,before
+Cool, got it, will do it by end of next week.
+"""
+
+    model = imsc_reader.to_model(et.ElementTree(et.fromstring(ttml_doc_str)))
+    vtt_from_model = vtt_writer.from_model(model, None)
+    self.assertEqual(expected_vtt, vtt_from_model)
+
   def test_scc_test_suite(self):
     for root, _subdirs, files in os.walk("src/test/resources/scc"):
       for filename in files:

--- a/src/test/python/test_vtt_writer.py
+++ b/src/test/python/test_vtt_writer.py
@@ -130,12 +130,12 @@ Pellentesque interdum lacinia sollicitudin.
     expected_vtt="""WEBVTT
 
 1
-00:00:03.501 --> 00:00:12.000 line:90%,after
+00:00:03.501 --> 00:00:12.000 line:90%,end
 Only one or two short samples are needed
 to make sure the conversion basically works
 
 2
-00:00:14.375 --> 00:00:25.709 line:10%,before
+00:00:14.375 --> 00:00:25.709 line:10%,start
 Cool, got it, will do it by end of next week.
 """
 


### PR DESCRIPTION
Closes #356 

`tt convert -i <.ttml file> -o <.vtt file> --itype TTML --otype VTT --config '{"vtt_writer": {"line_position":true}}'`
