### PR TITLE
Disallow 'c' units for all style properties with the exception of ebutts:linePadding

### DIFF
--- a/src/test/python/test_isd.py
+++ b/src/test/python/test_isd.py
@@ -326,6 +326,7 @@ class ComputeStyleTest(unittest.TestCase):
     self.assertAlmostEqual(extent.height.value, 100*25/doc.get_px_resolution().height)
     self.assertEqual(extent.height.units, styles.LengthType.Units.rh)
 
+  @unittest.skip("Removing support for 'c' units other with ebutts:linePadding")
   def test_compute_extent_c(self):
     doc = model.ContentDocument()
 


### PR DESCRIPTION
Enforces the IMSC data model where 'c' units are disallowed on all style properties with the exception of ebutts:linePadding

Closes #336 