### PR TITLE
SCC: Use quotation mark instead of 2 backquote chars

### DIFF
--- a/src/main/python/ttconv/scc/codes/standard_characters.py
+++ b/src/main/python/ttconv/scc/codes/standard_characters.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 SCC_STANDARD_CHARACTERS_MAPPING = dict([
   (0x20, " "),  # Standard space
   (0x21, "!"),  # Exclamation mark
-  (0x22, "``"),  # Quotation mark
+  (0x22, "\""),  # Quotation mark
   (0x23, "#"),  # Pounds (number) sign
   (0x24, "$"),  # Dollar sign
   (0x25, "%"),  # Percentage sign

--- a/src/test/python/test_scc_standard_characters.py
+++ b/src/test/python/test_scc_standard_characters.py
@@ -37,7 +37,7 @@ class SccStandardCharactersTest(unittest.TestCase):
   def test_scc_standard_character_values(self):
     self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x20], " ")
     self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x21], "!")
-    self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x22], "``")
+    self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x22], '"')
     self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x23], "#")
     self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x24], "$")
     self.assertEqual(SCC_STANDARD_CHARACTERS_MAPPING[0x25], "%")


### PR DESCRIPTION
Hello,
I notice that SCC character "quotation mark" is translated into two backquote characters ` `` ` instead of a single quotation mark ` " `
 ( hex char `0x22` in https://en.wikipedia.org/wiki/EIA-608)
Is it a mistake?

