### PR TITLE
Add VTT vertical position support when converting from ttml

### DIFF
--- a/src/main/python/ttconv/imsc/style_properties.py
+++ b/src/main/python/ttconv/imsc/style_properties.py
@@ -1114,8 +1114,11 @@ class StyleProperties:
       if xml_attrib == "rl":
         return styles.WritingModeType.rltb
 
-      if xml_attrib == "tb":
-        return styles.WritingModeType.tbrl
+      if xml_attrib.startswith("tb"):
+        if xml_attrib == "tbrl":
+          return styles.WritingModeType.tbrl
+        elif xml_attrib == "tbrl"
+          return styles.WritingModeType.tblr
 
       return styles.WritingModeType[xml_attrib]
 

--- a/src/main/python/ttconv/isd.py
+++ b/src/main/python/ttconv/isd.py
@@ -394,7 +394,8 @@ class ISD(model.Document):
     styles.StyleProperties.TextOutline,
     styles.StyleProperties.TextShadow,
     styles.StyleProperties.TextEmphasis,
-    styles.StyleProperties.Padding
+    styles.StyleProperties.Padding,
+    styles.StyleProperties.WritingMode
   )
 
   @staticmethod

--- a/src/main/python/ttconv/style_properties.py
+++ b/src/main/python/ttconv/style_properties.py
@@ -963,7 +963,7 @@ class StyleProperties:
     '''Corresponds to tts:writingMode
     '''
 
-    is_inherited = False
+    is_inherited = True
     is_animatable = True
 
     @staticmethod

--- a/src/main/python/ttconv/vtt/config.py
+++ b/src/main/python/ttconv/vtt/config.py
@@ -46,3 +46,6 @@ class VTTWriterConfiguration(ModuleConfiguration):
 
   # outputs cue identifier
   cue_id: bool = field(default=True, metadata={"decoder": bool})
+
+  # vertical positioning
+  vertical_position: bool = field(default=False, metadata={"decoder": bool})

--- a/src/main/python/ttconv/vtt/cue.py
+++ b/src/main/python/ttconv/vtt/cue.py
@@ -47,6 +47,13 @@ class VttCue:
     left = "left"
     center = "center"
     right = "right"
+    start = "start"
+    end = "end"
+
+  class Vertical(Enum):
+    """WebVTT vertical positioning cue setting"""
+    lr = "lr"  # left to right
+    rl = "rl"  # right to left
 
   _EOL_SEQ_RE = re.compile(r"\n{2,}")
 
@@ -55,9 +62,12 @@ class VttCue:
     self._begin: Optional[ClockTime] = None
     self._end: Optional[ClockTime] = None
     self._text: str = ""
+    self._position: int = None
+    self._size: int = None
     self._line: int = None
     self._linealign: VttCue.LineAlignment = None
     self._textalign: VttCue.TextAlignment = None
+    self._vertical: VttCue.Vertical = None
 
   def set_begin(self, offset: Fraction):
     """Sets the paragraph begin time code"""
@@ -95,6 +105,30 @@ class VttCue:
   def get_align(self) -> Optional[LineAlignment]:
     """Return the WebVTT line alignment cue setting"""
     return self._linealign
+    
+  def set_vertical(self, vertical: Vertical):
+    """Sets the WebVTT vertical positioning cue setting"""
+    self._vertical = vertical
+
+  def get_vertical(self) -> Optional[Vertical]:
+    """Returns the WebVTT vertical positioning cue setting"""
+    return self._vertical
+
+  def set_position(self, position: int):
+    """Sets the WebVTT position cue setting (in whole percent)"""
+    self._position = position
+
+  def get_position(self) -> Optional[int]:
+    """Returns the WebVTT position cue setting (in whole percent)"""
+    return self._position
+
+  def set_size(self, size: int):
+    """Sets the WebVTT size cue setting (in whole percent)"""
+    self._size = size
+  
+  def get_size(self) -> Optional[int]:
+    """Returns the WebVTT size cue setting (in whole percent)"""
+    return self._size
 
   def set_textalign(self, textalign: TextAlignment):
     """Sets the WebVTT text alignment cue setting"""
@@ -134,6 +168,10 @@ class VttCue:
     # cue timing
     t += f"{self._begin} --> {self._end}"
 
+    # cue vertical positioning
+    if self._vertical is not None:
+      t += f" vertical:{self._vertical.value}"
+
     # cue text position
     if self._textalign is not None:
       t += f" align:{self._textalign.value}"
@@ -144,6 +182,13 @@ class VttCue:
 
       if self._linealign is not None:
         t += f",{self._linealign.value}"
+        
+    # cue position
+    if self._position is not None:
+      t += f" position:{self._position}%"
+
+      if self._size is not None:
+        t += f" size:{self._size}%"
 
     t += "\n"
 


### PR DESCRIPTION
Hello, team! Thanks for this awesome tool for helping us convert the subtitle format. My team is mainly working on the APAC related subtitles and we found there are some issues while converting the ttml file to VTT. One of the problem is that the output VTT file didn't include the vertical information even though the original ttml writingMode was defined the vertical subtitle in layout field. I added some configuration in VTT writer side so that when converting from ttml file, the vertical subtitle could be reserved. Thanks for reviewing and please let me know if there is any other cases we need to consider. Example screenshot below. 
![画像 (1)](https://github.com/user-attachments/assets/6aeab154-0a0b-456d-9b6f-130b190a4bc0)
