### PR TITLE
475: VTT reader does not display cues with negative line attribute values

### DIFF
--- a/src/main/python/ttconv/vtt/reader.py
+++ b/src/main/python/ttconv/vtt/reader.py
@@ -292,9 +292,9 @@ def _get_or_make_region(
       line_num = parse_vtt_int(value[0])
       if line_num is not None:
         if writing_mode in (styles.WritingModeType.rltb, styles.WritingModeType.lrtb):
-          line_offset = 100 * line_num/_DEFAULT_ROWS if line_num > 0 else 100 + 100 * line_num/_DEFAULT_ROWS
+          line_offset = 100 * line_num/_DEFAULT_ROWS if line_num >= 0 else 100 + 100 * line_num/_DEFAULT_ROWS
         else:
-          line_offset = 100 * line_num/_DEFAULT_COLS if line_num > 0 else 100 + 100 * line_num/_DEFAULT_COLS
+          line_offset = 100 * line_num/_DEFAULT_COLS if line_num >= 0 else 100 + 100 * line_num/_DEFAULT_COLS
 
     if line_offset is not None:
       if line_align == "center":

--- a/src/test/python/test_vtt_reader.py
+++ b/src/test/python/test_vtt_reader.py
@@ -322,26 +322,36 @@ Red or green?
   def test_line_origin_extent(self):
     f = io.StringIO(r"""WEBVTT
 
-00:00:00.000 --> 00:00:02.000 line:1
-Line 1 starting from top
+1
+00:00:00.000 --> 00:00:02.000 line:0
+Line 0 starting from top
 
-00:00:03.000 --> 00:00:05.000 line:45%
+2
+00:00:03.000 --> 00:00:05.000 line:5
+Line 5 starting from top
+
+3
+00:00:06.000 --> 00:00:08.000 line:45%
 Line in percentage
 
-00:00:07.000 --> 00:00:09.000 line:-1
+4
+00:00:09.000 --> 00:00:11.000 line:-1
 Line 1 starting from bottom
 """)
     doc = to_model(f)
     regions = list(doc.iter_regions())
-    # line 1 starting from top
-    self.assertEqual(round(regions[0].get_style(styles.StyleProperties.Origin).y.value), 4)
-    self.assertEqual(round(regions[0].get_style(styles.StyleProperties.Extent).height.value), 96)
+    # line 0 starting from top
+    self.assertEqual(round(regions[0].get_style(styles.StyleProperties.Origin).y.value), 0)
+    self.assertEqual(round(regions[0].get_style(styles.StyleProperties.Extent).height.value), 100)
+    # line 5 starting from top
+    self.assertEqual(round(regions[1].get_style(styles.StyleProperties.Origin).y.value), 22)
+    self.assertEqual(round(regions[1].get_style(styles.StyleProperties.Extent).height.value), 78)
     # line in percentage
-    self.assertEqual(round(regions[1].get_style(styles.StyleProperties.Origin).y.value), 45)
-    self.assertEqual(round(regions[1].get_style(styles.StyleProperties.Extent).height.value), 55)
+    self.assertEqual(round(regions[2].get_style(styles.StyleProperties.Origin).y.value), 45)
+    self.assertEqual(round(regions[2].get_style(styles.StyleProperties.Extent).height.value), 55)
     # line 1 starting from bottom
-    self.assertEqual(round(regions[2].get_style(styles.StyleProperties.Origin).y.value), 96)
-    self.assertEqual(round(regions[2].get_style(styles.StyleProperties.Extent).height.value), 4)
+    self.assertEqual(round(regions[3].get_style(styles.StyleProperties.Origin).y.value), 96)
+    self.assertEqual(round(regions[3].get_style(styles.StyleProperties.Extent).height.value), 4)
 
 
 


### PR DESCRIPTION
Integer line values can be positive or negative. When positive, lines are counted from the top of the screen, and when negative, from the bottom of the screen.

The code did not handle negative values correctly, as line positions ended up greater than 100(%), hence out of the screen.
The fix handles negative values properly and adds a test case for both positive/negative integers and percentage.

Note that line value 0 should probably be handled as a positive value, but I did not change the current logic to remain backward compatible.

Closes #475 