### PR TITLE
Fix STL30.01 DFC mapping to use 30fps & add STL29.01

### DIFF
--- a/src/main/python/ttconv/stl/datafile.py
+++ b/src/main/python/ttconv/stl/datafile.py
@@ -163,7 +163,8 @@ _DFC_FRACTION_MAP = {
   b'STL23.01': Fraction(24000, 1001),
   b'STL24.01': Fraction(24),
   b'STL25.01': Fraction(25),
-  b'STL30.01': Fraction(30000, 1001),
+  b'STL29.01': Fraction(30000, 1001),
+  b'STL30.01': Fraction(30),
   b'STL50.01': Fraction(50)
 }
 


### PR DESCRIPTION
Per EBU Tech 3264 section 4.2.2, `STL30.01` specifies 30 FPS, not 29.97 FPS.

This change corrects the mapping and adds STL29.01 → 29.97 FPS as a non-standard extension for files that use that convention (e.g. as used by Subtitle Edit).

Fixes #504