### PR TITLE
Fix SCC NDF timecode drift: parse at FPS_29_97, fix add_frames() DF flag

### DIFF
--- a/src/main/python/ttconv/scc/line.py
+++ b/src/main/python/ttconv/scc/line.py
@@ -42,7 +42,7 @@ from ttconv.scc.codes.special_characters import SccSpecialCharacter
 from ttconv.scc.context import SccContext
 from ttconv.scc.disassembly import get_scc_word_disassembly
 from ttconv.scc.word import SccWord
-from ttconv.time_code import SmpteTimeCode, FPS_30
+from ttconv.time_code import SmpteTimeCode, FPS_29_97
 
 LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class SccLine:
       return None
 
     time_code = match.group(1)
-    time_offset = SmpteTimeCode.parse(time_code, FPS_30)
+    time_offset = SmpteTimeCode.parse(time_code, FPS_29_97)
 
     hex_words = line.split('\t')[1].split(' ')
     scc_words = [SccWord.from_str(hex_word) for hex_word in hex_words if hex_word]

--- a/src/main/python/ttconv/time_code.py
+++ b/src/main/python/ttconv/time_code.py
@@ -211,7 +211,7 @@ class SmpteTimeCode(_HHMMSSTimeExpression):
     """Add frames to the current time code"""
     frames = self.to_frames() + nb_frames
 
-    new_time_code = SmpteTimeCode.from_frames(frames, self._frame_rate)
+    new_time_code = SmpteTimeCode.from_frames(frames, self._frame_rate, self._is_drop_frame)
 
     self._hours = new_time_code.get_hours()
     self._minutes = new_time_code.get_minutes()

--- a/src/test/python/test_scc_line.py
+++ b/src/test/python/test_scc_line.py
@@ -30,16 +30,36 @@ import unittest
 
 from ttconv.scc.line import SccLine
 from ttconv.scc.caption_style import SccCaptionStyle
-from ttconv.time_code import SmpteTimeCode, FPS_30
+from ttconv.time_code import SmpteTimeCode, FPS_29_97
 
 
 class SccLineTest(unittest.TestCase):
+
+  def test_scc_line_from_str_ndf_timecode_uses_fps_29_97(self):
+    """NDF SCC timecodes (colon-delimited) are parsed at 29.97 fps, non-drop-frame."""
+    line_str = "01:00:00:00	9420 9420"
+    scc_line = SccLine.from_str(line_str)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_29_97, scc_line.time_code.get_frame_rate())
+    self.assertFalse(scc_line.time_code.is_drop_frame())
+    # 01:00:00:00 NDF at 29.97 fps = ~3603.6s (slightly longer than clock hour due to 1/29.97 frame duration)
+    self.assertEqual(SmpteTimeCode(1, 0, 0, 0, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+
+  def test_scc_line_from_str_df_timecode_is_drop_frame(self):
+    """DF SCC timecodes (semicolon-delimited) are parsed as drop-frame 29.97 fps."""
+    line_str = "01:00:00;00	9420 9420"
+    scc_line = SccLine.from_str(line_str)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_29_97, scc_line.time_code.get_frame_rate())
+    self.assertTrue(scc_line.time_code.is_drop_frame())
+    # 01:00:00;00 DF at 29.97 fps = ~3600.0s (drop-frame compensates back to real clock time)
+    self.assertEqual(SmpteTimeCode(1, 0, 0, 0, FPS_29_97, True).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
 
   def test_scc_line_from_str_with_pop_on_style(self):
     line_str = "01:03:27:29	94ae 94ae 9420 9420 94f2 94f2 c845 d92c 2054 c845 5245 ae80 942c 942c 8080 8080 942f 942f"
     scc_line = SccLine.from_str(line_str)
     self.assertEqual(18, len(scc_line.scc_words))
-    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_30).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	{ENM}{ENM}{RCL}{RCL}{1504}{1504}HEY, THERE.{EDM}{EDM}{}{}{EOC}{EOC}", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.PopOn, scc_line.get_style())
 
@@ -51,14 +71,14 @@ class SccLineTest(unittest.TestCase):
     line_str = "01:03:27:29	"
     scc_line = SccLine.from_str(line_str)
     self.assertEqual(0, len(scc_line.scc_words))
-    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_30).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.Unknown, scc_line.get_style())
 
     line_str = "01:03:27:29	9024 c845 d92c 2054 c845 5245 ae80 9f9f"
     scc_line = SccLine.from_str(line_str)
     self.assertEqual(8, len(scc_line.scc_words))
-    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_30).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	{BBl}HEY, THERE.{??}", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.Unknown, scc_line.get_style())
 
@@ -66,7 +86,7 @@ class SccLineTest(unittest.TestCase):
     line_str = "01:03:27:29	9425 9425 94ad 94ad 94c8 94c8 c845 d92c 2054 c845 5245 ae80"
     scc_line = SccLine.from_str(line_str)
     self.assertEqual(12, len(scc_line.scc_words))
-    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_30).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	{RU2}{RU2}{CR}{CR}{14R}{14R}HEY, THERE.", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.RollUp, scc_line.get_style())
 
@@ -74,6 +94,6 @@ class SccLineTest(unittest.TestCase):
     line_str = "01:03:27:29	9429 9429 94f2 94f2 c845 d92c 2054 c845 5245 ae80"
     scc_line = SccLine.from_str(line_str)
     self.assertEqual(10, len(scc_line.scc_words))
-    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_30).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
+    self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	{RDC}{RDC}{1504}{1504}HEY, THERE.", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.PaintOn, scc_line.get_style())

--- a/src/test/python/test_scc_reader.py
+++ b/src/test/python/test_scc_reader.py
@@ -38,7 +38,7 @@ from ttconv.scc.codes.attribute_codes import SccAttributeCode
 from ttconv.scc.reader import to_model, to_disassembly
 from ttconv.style_properties import StyleProperties, CoordinateType, LengthType, FontStyleType, NamedColors, TextDecorationType, \
   StyleProperty, ExtentType, ColorType, DisplayAlignType, ShowBackgroundType
-from ttconv.time_code import FPS_29_97, SmpteTimeCode, FPS_30
+from ttconv.time_code import FPS_29_97, SmpteTimeCode
 
 LOREM_IPSUM = """Lorem ipsum dolor sit amet,
 consectetur adipiscing elit.
@@ -70,7 +70,7 @@ class SccReaderTest(unittest.TestCase):
         self.assertEqual(expected_child, Br)
 
   def check_element_timecode(self, timecode: Fraction, expected_timecode: str):
-    self.assertEqual(SmpteTimeCode.parse(expected_timecode, FPS_30).to_temporal_offset(), timecode)
+    self.assertEqual(SmpteTimeCode.parse(expected_timecode, FPS_29_97).to_temporal_offset(), timecode)
 
   def check_element_style(self, elem: ContentElement, style_property: Type[StyleProperty], expected_value):
     self.assertEqual(expected_value, elem.get_style(style_property))
@@ -805,10 +805,10 @@ Scenarist_SCC V1.0
     self.assertEqual(region_1, paragraph.get_region())
 
     self.assertIsNone(list(paragraph)[0].get_begin())
-    self.assertAlmostEqual(1/30 * 4, float(list(paragraph)[1].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 7, float(list(paragraph)[2].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 10, float(list(paragraph)[3].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 12, float(list(paragraph)[4].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 4, float(list(paragraph)[1].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 7, float(list(paragraph)[2].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 10, float(list(paragraph)[3].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 12, float(list(paragraph)[4].get_begin()), delta=0.0001)
 
     paragraph = p_list[1]
     self.check_caption(paragraph, "caption2", "00:02:54:02", "00:02:56:02", "Lorem ", "ipsum ", "dolor ", "sit ", "amet,", Br,
@@ -821,8 +821,8 @@ Scenarist_SCC V1.0
     self.assertIsNone(list(paragraph)[3].get_begin())
     self.assertIsNone(list(paragraph)[4].get_begin())
     self.assertIsNone(list(paragraph)[6].get_begin())
-    self.assertAlmostEqual(1/30 * 7, float(list(paragraph)[7].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 13, float(list(paragraph)[8].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 7, float(list(paragraph)[7].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 13, float(list(paragraph)[8].get_begin()), delta=0.0001)
 
     paragraph = p_list[2]
     self.check_caption(paragraph, "caption3", "00:02:56:02", "00:02:56:27", "Pellentesque", " interdum ", "lacinia ",
@@ -830,9 +830,9 @@ Scenarist_SCC V1.0
     self.assertEqual(region_1, paragraph.get_region())
 
     self.assertIsNone(list(paragraph)[0].get_begin())
-    self.assertAlmostEqual(1/30 * 8, float(list(paragraph)[1].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 12, float(list(paragraph)[2].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 16, float(list(paragraph)[3].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 8, float(list(paragraph)[1].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 12, float(list(paragraph)[2].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 16, float(list(paragraph)[3].get_begin()), delta=0.0001)
     self.assertIsNone(list(paragraph)[5].get_begin())
     self.assertIsNone(list(paragraph)[6].get_begin())
     self.assertIsNone(list(paragraph)[7].get_begin())
@@ -848,11 +848,11 @@ Scenarist_SCC V1.0
     self.assertIsNone(list(paragraph)[2].get_begin())
     self.assertIsNone(list(paragraph)[3].get_begin())
     self.assertIsNone(list(paragraph)[5].get_begin())
-    self.assertAlmostEqual(1/30 * 5, float(list(paragraph)[6].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 9, float(list(paragraph)[7].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 10, float(list(paragraph)[8].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 14, float(list(paragraph)[9].get_begin()), delta=0.0001)
-    self.assertAlmostEqual(1/30 * 15, float(list(paragraph)[10].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 5, float(list(paragraph)[6].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 9, float(list(paragraph)[7].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 10, float(list(paragraph)[8].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 14, float(list(paragraph)[9].get_begin()), delta=0.0001)
+    self.assertAlmostEqual(1/29.97 * 15, float(list(paragraph)[10].get_begin()), delta=0.0001)
 
     for p in p_list:
       for span in [elem for elem in list(p) if isinstance(elem, Span)]:

--- a/src/test/python/test_time_code_smpte.py
+++ b/src/test/python/test_time_code_smpte.py
@@ -457,5 +457,17 @@ class SmpteTimeCodesTest(unittest.TestCase):
     self.assertEqual(Fraction(35964, Fraction(30000, 1001)), time_code.to_temporal_offset())
     self.assertEqual("00:20:00;00", str(time_code))
 
+    time_code = SmpteTimeCode.parse("01:00:59:29", FPS_29_97)
+    time_code.add_frames()
+    self.assertEqual(1, time_code.get_hours())
+    self.assertEqual(1, time_code.get_minutes())
+    self.assertEqual(0, time_code.get_seconds())
+    self.assertEqual(0, time_code.get_frames())
+    self.assertEqual(FPS_29_97, time_code.get_frame_rate())
+    self.assertFalse(time_code.is_drop_frame())
+    self.assertEqual(109_800, time_code.to_frames())
+    self.assertEqual(Fraction(109_800, FPS_29_97), time_code.to_temporal_offset())
+    self.assertEqual("01:01:00:00", str(time_code))
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This change addresses 2 related issues:

1. SCC files were parsed assuming 30 FPS instead of 29.97 FPS, causing ~3.6s/hour of timing drift for Non-Drop Frame (NDF) content. Drop Frame (DF) content was unaffected because `SmpteTimeCode.parse()` already applied a 1000/1001 rate correction for DF timecodes, which happened to compensate for the wrong input rate.

2. `add_frames()` re-derived the DF/NDF flag from the frame rate denominator instead of preserving it from the original timecode, silently converting NDF 29.97 timecodes to drop-frame after the first frame advance.

## References
- [Telestream](https://support.telestream.net/s/article/SCC-Files-and-23-98-fps-or-Other-Frame-Rates)
- [theneitherworld.com](http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/SCC_FORMAT.HTML)

## Individual changes
- **`scc/line.py`** - Changed `FPS_30` to `FPS_29_97` when parsing SCC line timecodes. SCC (CEA-608) files carry no embedded framerate & 29.97 fps is the correct default (NTSC framerate as defined in CEA-608).

- **`time_code.py`** - `add_frames()` now passes `self._is_drop_frame` explicitly to `from_frames()`. Previously it defaulted `is_df` from the rate denominator, silently converting NDF FPS_29_97 timecodes to drop-frame on every frame advance as this was incorrectly based on the framerate denominator.

- **`test_scc_line.py`** - Existing timecode assertions updated from `FPS_30` to `FPS_29_97` (with explicit `is_df=False` for NDF). New paired tests added asserting NDF and DF SCC line timecodes parse to the correct frame rate and drop-frame flag.

4. **`test_scc_reader.py`** - `check_element_timecode()` helper updated to parse expected timecodes at `FPS_29_97`. Per-frame span offset assertions updated from `1/30 * N` to `1/29.97 * N`.


Closes #508 
Closes #507 