### PR TITLE
Add SCC Reader support for configurable framerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,15 @@ text alignment.
 
 Default: `"auto"`
 
+#### frame_rate
+
+`"frame_rate" : "29.97" | "30" | "25" | "23.976"`
+
+Specifies the frame rate used to interpret timecodes in the SCC file. Drop-frame vs.
+non-drop-frame is detected automatically from the timecode delimiter.
+
+Default: `"29.97"`
+
 ### SCC Writer configuration
 
 #### allow_reflow
@@ -298,7 +307,7 @@ If `frame_rate` is:
 * `"29.97NDF"`, the output SCC file uses 29.97 fps non drop frame (NDF) timecode.
 * `"29.97DF"`, the output SCC file uses 29.97 fps drop frame (DF) timecode.
 
-Default: `"2997DF"`
+Default: `"29.97DF"`
 
 #### start_tc
 

--- a/src/main/python/ttconv/scc/config.py
+++ b/src/main/python/ttconv/scc/config.py
@@ -61,6 +61,31 @@ class TextAlignment(Enum):
 
     raise ValueError(f"Invalid text align '{value}' value. Expect: 'left', 'center', 'right' or 'auto'.")
 
+class SCCReaderFrameRate(Enum):
+  """SCC Reader Frame Rates — encodes fps only; DF/NDF is detected from the timecode delimiter in the file."""
+
+  FPS_30   = ("30",     Fraction(30))
+  FPS_2997 = ("29.97",  Fraction(30000, 1001))
+  FPS_25   = ("25",     Fraction(25))
+  FPS_2398 = ("23.976", Fraction(24000, 1001))
+
+  def __init__(self, label: str, fps: Fraction):
+    self.label: str = label
+    self.fps: Fraction = fps
+
+  @staticmethod
+  def from_value(value: str | SCCReaderFrameRate) -> SCCReaderFrameRate:
+    """Create a SCCReaderFrameRate from a string label or existing instance"""
+    if isinstance(value, SCCReaderFrameRate):
+      return value
+
+    if isinstance(value, str):
+      for e in list(SCCReaderFrameRate):
+        if value.lower() == e.label.lower():
+          return e
+
+    raise ValueError(f"Invalid SCC Reader Frame Rate '{value}'. Expect {', '.join([e.label for e in list(SCCReaderFrameRate)])}.")
+
 class SCCFrameRate(Enum):
   """SCC Frame Rates"""
 
@@ -93,6 +118,11 @@ class SccReaderConfiguration(ModuleConfiguration):
   text_align: TextAlignment = field(
     default=TextAlignment.AUTO,
     metadata={"decoder": TextAlignment.from_value}
+  )
+
+  frame_rate: typing.Optional[SCCReaderFrameRate] = field(
+    default=None,
+    metadata={"decoder": lambda v: SCCReaderFrameRate.from_value(v) if v is not None else None}
   )
 
   @classmethod

--- a/src/main/python/ttconv/scc/line.py
+++ b/src/main/python/ttconv/scc/line.py
@@ -39,6 +39,7 @@ from ttconv.scc.codes.extended_characters import SccExtendedCharacter
 from ttconv.scc.codes.mid_row_codes import SccMidRowCode
 from ttconv.scc.codes.preambles_address_codes import SccPreambleAddressCode
 from ttconv.scc.codes.special_characters import SccSpecialCharacter
+from ttconv.scc.config import SCCReaderFrameRate
 from ttconv.scc.context import SccContext
 from ttconv.scc.disassembly import get_scc_word_disassembly
 from ttconv.scc.word import SccWord
@@ -65,7 +66,7 @@ class SccLine:
     self.scc_words = scc_words
 
   @staticmethod
-  def from_str(line: str) -> Optional[SccLine]:
+  def from_str(line: str, frame_rate: Optional[SCCReaderFrameRate] = None) -> Optional[SccLine]:
     """Creates a SCC line instance from the specified string"""
     if not line:
       return None
@@ -77,7 +78,8 @@ class SccLine:
       return None
 
     time_code = match.group(1)
-    time_offset = SmpteTimeCode.parse(time_code, FPS_29_97)
+    fps = frame_rate.fps if frame_rate is not None else FPS_29_97
+    time_offset = SmpteTimeCode.parse(time_code, fps)
 
     hex_words = line.split('\t')[1].split(' ')
     scc_words = [SccWord.from_str(hex_word) for hex_word in hex_words if hex_word]

--- a/src/main/python/ttconv/scc/reader.py
+++ b/src/main/python/ttconv/scc/reader.py
@@ -88,9 +88,11 @@ def to_model(scc_content: str, config: Optional[SccReaderConfiguration] = None, 
   lines = scc_content.splitlines()
   nb_lines = len(lines)
 
+  frame_rate = config.frame_rate if config is not None else None
+
   for (index, line) in enumerate(lines):
     LOGGER.debug(line)
-    scc_line = SccLine.from_str(line)
+    scc_line = SccLine.from_str(line, frame_rate)
 
     progress_callback((index + 1) / nb_lines)
 

--- a/src/test/python/test_scc_line.py
+++ b/src/test/python/test_scc_line.py
@@ -30,7 +30,8 @@ import unittest
 
 from ttconv.scc.line import SccLine
 from ttconv.scc.caption_style import SccCaptionStyle
-from ttconv.time_code import SmpteTimeCode, FPS_29_97
+from ttconv.scc.config import SCCReaderFrameRate
+from ttconv.time_code import SmpteTimeCode, FPS_29_97, FPS_30, FPS_25, FPS_23_98
 
 
 class SccLineTest(unittest.TestCase):
@@ -97,3 +98,55 @@ class SccLineTest(unittest.TestCase):
     self.assertEqual(SmpteTimeCode(1, 3, 27, 29, FPS_29_97, False).to_temporal_offset(), scc_line.time_code.to_temporal_offset())
     self.assertEqual("01:03:27:29	{RDC}{RDC}{1504}{1504}HEY, THERE.", scc_line.to_disassembly())
     self.assertEqual(SccCaptionStyle.PaintOn, scc_line.get_style())
+
+
+class SccLineFromStrFrameRateTest(unittest.TestCase):
+
+  NDF_LINE = "01:03:27:23\t9420 9420"
+  DF_LINE  = "01:03:27;23\t9420 9420"
+
+  def test_explicit_fps_30_ndf(self):
+    """FPS_30 config with NDF timecode uses 30 fps, non-drop-frame."""
+    scc_line = SccLine.from_str(self.NDF_LINE, SCCReaderFrameRate.FPS_30)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_30, scc_line.time_code.get_frame_rate())
+    self.assertFalse(scc_line.time_code.is_drop_frame())
+    expected = SmpteTimeCode(1, 3, 27, 23, FPS_30, False).to_temporal_offset()
+    self.assertEqual(expected, scc_line.time_code.to_temporal_offset())
+
+  def test_explicit_fps_2997_ndf(self):
+    """FPS_2997 config with NDF timecode uses 29.97 fps, non-drop-frame."""
+    scc_line = SccLine.from_str(self.NDF_LINE, SCCReaderFrameRate.FPS_2997)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_29_97, scc_line.time_code.get_frame_rate())
+    self.assertFalse(scc_line.time_code.is_drop_frame())
+    expected = SmpteTimeCode(1, 3, 27, 23, FPS_29_97, False).to_temporal_offset()
+    self.assertEqual(expected, scc_line.time_code.to_temporal_offset())
+
+  def test_explicit_fps_2997_df(self):
+    """FPS_2997 config with DF timecode detects drop-frame from delimiter."""
+    scc_line = SccLine.from_str(self.DF_LINE, SCCReaderFrameRate.FPS_2997)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_29_97, scc_line.time_code.get_frame_rate())
+    self.assertTrue(scc_line.time_code.is_drop_frame())
+    expected = SmpteTimeCode(1, 3, 27, 23, FPS_29_97, True).to_temporal_offset()
+    self.assertEqual(expected, scc_line.time_code.to_temporal_offset())
+
+  def test_explicit_fps_25_ndf(self):
+    """FPS_25 config with NDF timecode uses 25 fps, non-drop-frame."""
+    scc_line = SccLine.from_str(self.NDF_LINE, SCCReaderFrameRate.FPS_25)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_25, scc_line.time_code.get_frame_rate())
+    self.assertFalse(scc_line.time_code.is_drop_frame())
+    expected = SmpteTimeCode(1, 3, 27, 23, FPS_25, False).to_temporal_offset()
+    self.assertEqual(expected, scc_line.time_code.to_temporal_offset())
+
+  def test_explicit_fps_2398_ndf(self):
+    """FPS_2398 config with NDF timecode uses 23.976 fps, non-drop-frame."""
+    scc_line = SccLine.from_str(self.NDF_LINE, SCCReaderFrameRate.FPS_2398)
+    self.assertIsNotNone(scc_line)
+    self.assertEqual(FPS_23_98, scc_line.time_code.get_frame_rate())
+    self.assertFalse(scc_line.time_code.is_drop_frame())
+    expected = SmpteTimeCode(1, 3, 27, 23, FPS_23_98, False).to_temporal_offset()
+    self.assertEqual(expected, scc_line.time_code.to_temporal_offset())
+

--- a/src/test/python/test_scc_reader.py
+++ b/src/test/python/test_scc_reader.py
@@ -36,9 +36,10 @@ from ttconv.isd import ISD
 from ttconv.model import Br, P, ContentElement, CellResolutionType, Span
 from ttconv.scc.codes.attribute_codes import SccAttributeCode
 from ttconv.scc.reader import to_model, to_disassembly
+from ttconv.scc.config import SccReaderConfiguration, SCCReaderFrameRate
 from ttconv.style_properties import StyleProperties, CoordinateType, LengthType, FontStyleType, NamedColors, TextDecorationType, \
   StyleProperty, ExtentType, ColorType, DisplayAlignType, ShowBackgroundType
-from ttconv.time_code import FPS_29_97, SmpteTimeCode
+from ttconv.time_code import FPS_29_97, FPS_30, FPS_25, FPS_23_98, SmpteTimeCode
 
 LOREM_IPSUM = """Lorem ipsum dolor sit amet,
 consectetur adipiscing elit.
@@ -71,6 +72,9 @@ class SccReaderTest(unittest.TestCase):
 
   def check_element_timecode(self, timecode: Fraction, expected_timecode: str):
     self.assertEqual(SmpteTimeCode.parse(expected_timecode, FPS_29_97).to_temporal_offset(), timecode)
+
+  def check_element_timecode_at_fps(self, timecode: Fraction, expected_timecode: str, fps: Fraction):
+    self.assertEqual(SmpteTimeCode.parse(expected_timecode, fps).to_temporal_offset(), timecode)
 
   def check_element_style(self, elem: ContentElement, style_property: Type[StyleProperty], expected_value):
     self.assertEqual(expected_value, elem.get_style(style_property))
@@ -1540,6 +1544,49 @@ Scenarist_SCC V1.0
 
     self.check_caption(p_list[0], "caption1", "01:03:28:21", None, "HEY, THERE.")
     self.assertEqual(region_1, p_list[0].get_region())
+
+
+  def test_scc_reader_all_ndf_framerates_parse_without_error(self):
+    """All SCCReaderFrameRate values can be used to parse an SCC document."""
+    scc_content = "\n".join([
+      "Scenarist_SCC V1.0",
+      "",
+      "01:03:27:23\t94ae 94ae 9420 9420 94f4 94f4 c845 d92c 942c 942c 942f 942f",
+      "",
+    ])
+    ndf_fps_map = {
+      SCCReaderFrameRate.FPS_30:   (FPS_30,    "01:03:28:03"),
+      SCCReaderFrameRate.FPS_2997: (FPS_29_97, "01:03:28:03"),
+      SCCReaderFrameRate.FPS_25:   (FPS_25,    "01:03:28:08"),
+      SCCReaderFrameRate.FPS_2398: (FPS_23_98, "01:03:28:09"),
+    }
+    for fr, (fps, expected_tc) in ndf_fps_map.items():
+      with self.subTest(frame_rate=fr.label):
+        config = SccReaderConfiguration(frame_rate=fr)
+        doc = to_model(scc_content, config)
+        p_list = list(list(doc.get_body())[0])
+        self.assertEqual(1, len(p_list))
+        self.check_element_timecode_at_fps(p_list[0].get_begin(), expected_tc, fps)
+
+  def test_scc_reader_all_df_framerates_parse_without_error(self):
+    """DF timecode delimiter is detected correctly for fractional framerates."""
+    scc_content = "\n".join([
+      "Scenarist_SCC V1.0",
+      "",
+      "01:03:27;23\t94ae 94ae 9420 9420 94f4 94f4 c845 d92c 942c 942c 942f 942f",
+      "",
+    ])
+    df_fps_map = {
+      SCCReaderFrameRate.FPS_2997: (FPS_29_97, "01:03:28;03"),
+      SCCReaderFrameRate.FPS_2398: (FPS_23_98, "01:03:28;09"),
+    }
+    for fr, (fps, expected_tc) in df_fps_map.items():
+      with self.subTest(frame_rate=fr.label):
+        config = SccReaderConfiguration(frame_rate=fr)
+        doc = to_model(scc_content, config)
+        p_list = list(list(doc.get_body())[0])
+        self.assertEqual(1, len(p_list))
+        self.check_element_timecode_at_fps(p_list[0].get_begin(), expected_tc, fps)
 
 
 if __name__ == '__main__':

--- a/src/test/python/test_scc_reader_config.py
+++ b/src/test/python/test_scc_reader_config.py
@@ -29,7 +29,7 @@
 import json
 import unittest
 
-from ttconv.scc.config import SccReaderConfiguration, SccWriterConfiguration, TextAlignment
+from ttconv.scc.config import SccReaderConfiguration, SccWriterConfiguration, TextAlignment, SCCReaderFrameRate
 
 
 class SccReaderConfigurationTest(unittest.TestCase):
@@ -49,6 +49,7 @@ class SccReaderConfigurationTest(unittest.TestCase):
     scc_reader_configuration = SccReaderConfiguration.parse(config_dict)
 
     self.assertEqual(scc_reader_configuration, SccReaderConfiguration(text_align=TextAlignment.AUTO))
+    self.assertIsNone(scc_reader_configuration.frame_rate)
 
   def test_scc_reader_config_parsing_right_value(self):
     config_json = """{"text_align": "right" }"""
@@ -81,6 +82,34 @@ class SccReaderConfigurationTest(unittest.TestCase):
     scc_reader_configuration = SccReaderConfiguration.parse(config_dict)
 
     self.assertEqual(scc_reader_configuration, SccReaderConfiguration(text_align=TextAlignment.AUTO))
+
+  def test_scc_reader_config_parsing_frame_rate_values(self):
+    for label, expected in [("30", SCCReaderFrameRate.FPS_30),
+                             ("29.97", SCCReaderFrameRate.FPS_2997),
+                             ("25", SCCReaderFrameRate.FPS_25),
+                             ("23.976", SCCReaderFrameRate.FPS_2398)]:
+      with self.subTest(label=label):
+        config = SccReaderConfiguration.parse(json.loads(f'{{"frame_rate": "{label}"}}'))
+        self.assertEqual(expected, config.frame_rate)
+
+  def test_scc_reader_config_parsing_invalid_frame_rate_raises(self):
+    self.assertRaises(ValueError, SccReaderConfiguration.parse, json.loads('{"frame_rate": "60"}'))
+
+
+class SCCReaderFrameRateTest(unittest.TestCase):
+
+  def test_from_value_returns_instance_unchanged(self):
+    self.assertIs(SCCReaderFrameRate.FPS_2997, SCCReaderFrameRate.from_value(SCCReaderFrameRate.FPS_2997))
+
+  def test_from_value_parses_all_labels(self):
+    self.assertIs(SCCReaderFrameRate.FPS_30,   SCCReaderFrameRate.from_value("30"))
+    self.assertIs(SCCReaderFrameRate.FPS_2997, SCCReaderFrameRate.from_value("29.97"))
+    self.assertIs(SCCReaderFrameRate.FPS_25,   SCCReaderFrameRate.from_value("25"))
+    self.assertIs(SCCReaderFrameRate.FPS_2398, SCCReaderFrameRate.from_value("23.976"))
+
+  def test_from_value_invalid_raises(self):
+    self.assertRaisesRegex(ValueError, "Invalid SCC Reader Frame Rate '60'",
+                           SCCReaderFrameRate.from_value, "60")
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Addresses https://github.com/sandflow/ttconv/issues/509

It's been noted that using SCC files with non-standard framerates (i.e. those other than 29.97 NDF & 29.97 DF) is questionable practice and easily leads to confusion as there's no direct metadata embedded in the files indicating when this is the case, the original SCC implementation was an encoding of the data from CTA 608 data stream developed for NTSC broadcast at 29.97 fps.

However these files/workflows do occasionally exist in the real world. This change adds support for ingesting these files to enable them to be accurately converted to other formats, but stops short of extending the SCC output with additional non-standard framerates to discourage further use.