### PR TITLE
Do not crash on empty WebVTT input or empty SRT cue text

### DIFF
--- a/src/main/python/ttconv/srt/reader.py
+++ b/src/main/python/ttconv/srt/reader.py
@@ -270,6 +270,7 @@ def to_model(data_file: typing.IO, _config: SRTReaderConfiguration = None, progr
         return None
 
       current_p = model.P(doc)
+      subtitle_text = ""
 
       current_p.set_begin(
         int(m.group('begin_h')) * 3600 + 

--- a/src/main/python/ttconv/vtt/reader.py
+++ b/src/main/python/ttconv/vtt/reader.py
@@ -547,6 +547,8 @@ def to_model(data_file: typing.IO, _config = None, progress_callback=lambda _: N
   for line_index, line in enumerate(_none_terminated(lines)):
 
     if state is _State.START:
+      if line is None:
+        break
       if not line.startswith("WEBVTT"):
         LOGGER.warning("The first line of the file does not start with WEBVTT")
       state = _State.LOOKING

--- a/src/test/python/test_srt_reader.py
+++ b/src/test/python/test_srt_reader.py
@@ -546,6 +546,19 @@ Also no alignment tag
     self.assertNotIn("{\\an", text_content)
     self.assertIn("Multiple tags here", text_content)
 
+  def test_empty_cue_text(self):
+    # A cue whose text body is empty (a time line immediately followed by a
+    # blank line) used to raise UnboundLocalError.
+    f = io.StringIO(
+      "1\n"
+      "00:00:01,000 --> 00:00:04,000\n"
+      "\n"
+      "2\n"
+      "00:00:05,000 --> 00:00:08,000\n"
+      "Second\n"
+    )
+    self.assertIsNotNone(to_model(f))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/test/python/test_vtt_reader.py
+++ b/src/test/python/test_vtt_reader.py
@@ -438,5 +438,10 @@ Line 0 starting from top
     self.assertEqual(o.x.value, 100*1/40)
     self.assertEqual(e.width.value, 100 - 2*100*1/40)
 
+  def test_empty_input(self):
+    # An empty document used to raise AttributeError on the None sentinel.
+    self.assertIsNotNone(to_model(io.StringIO("")))
+    self.assertIsNotNone(to_model(io.StringIO("   \n")))
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
A couple of the subtitle readers raise on trivial input they otherwise tolerate.

`vtt.to_model` on an empty document crashes:

```python
import io, ttconv.vtt.reader as vtt
vtt.to_model(io.StringIO(""))   # AttributeError: 'NoneType' object has no attribute 'startswith'
```

An empty file leaves only the `None` terminator, and the `START` state calls `line.startswith("WEBVTT")` without the `None` check the other states have. Separately, `srt.to_model` hits `UnboundLocalError` on a cue whose text body is empty (a time line followed immediately by a blank line), since `subtitle_text` is only initialized once a non-empty text line is seen.

I guarded the `None` line in the WebVTT `START` state and initialized `subtitle_text` when the paragraph is created. Added a test for each; the srt and vtt reader suites pass.
