### PR TITLE
Ignore unmatched end tags in SRT text

### DIFF
--- a/src/main/python/ttconv/srt/reader.py
+++ b/src/main/python/ttconv/srt/reader.py
@@ -179,7 +179,11 @@ class _TextParser(HTMLParser):
       return
 
   def handle_endtag(self, tag):
-    self.parent = self.parent.parent()
+    # Ignore an unmatched end tag. Without this guard a stray "</b>" would
+    # walk the parent above the paragraph, and following text would be pushed
+    # onto the div or body, which only accept P children.
+    if isinstance(self.parent, model.Span):
+      self.parent = self.parent.parent()
 
   def handle_data(self, data):
     lines = data.split("\n")

--- a/src/test/python/test_srt_reader.py
+++ b/src/test/python/test_srt_reader.py
@@ -546,6 +546,22 @@ Also no alignment tag
     self.assertNotIn("{\\an", text_content)
     self.assertIn("Multiple tags here", text_content)
 
+  def test_unmatched_end_tag(self):
+    # A stray end tag with no matching start tag used to raise
+    # "TypeError: Children of body must be P instances".
+    f = io.StringIO(
+      "1\n"
+      "00:00:01,000 --> 00:00:04,000\n"
+      "</b>text\n"
+    )
+    doc = to_model(f)
+    self.assertIsNotNone(doc)
+    text_content = ""
+    for e in doc.get_body().dfs_iterator():
+      if isinstance(e, model.Text):
+        text_content += e.get_text()
+    self.assertIn("text", text_content)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
An SRT text line that contains an end tag with no matching start tag crashes:

```python
import io, ttconv.srt.reader as srt
srt.to_model(io.StringIO("1\n00:00:01,000 --> 00:00:04,000\n</b>text\n"))
# TypeError: Children of body must be P instances
```

`_TextParser.handle_endtag` walks `self.parent` up a level unconditionally, so a stray `</b>` moves the insertion point above the paragraph and the text that follows gets pushed onto the div or body, which only accept `P` children. I made it only move up when the current parent is actually a span it opened, which just ignores the unmatched tag. Added a test; the srt reader suite passes.
