### PR TITLE
SRT/VTT writer: treat whitespace-only lines as blank in normalize_eol (fixes #350)

### DIFF
--- a/src/main/python/ttconv/srt/paragraph.py
+++ b/src/main/python/ttconv/srt/paragraph.py
@@ -36,6 +36,7 @@ class SrtParagraph:
   """SRT paragraph definition class"""
 
   _EOL_SEQ_RE = re.compile(r"\n{2,}")
+  _WS_LINE_RE = re.compile(r"^[^\S\n]+$", re.MULTILINE)
 
   def __init__(self, identifier: int):
     self._id: int = identifier
@@ -70,8 +71,11 @@ class SrtParagraph:
 
   def normalize_eol(self):
     """Remove line breaks at the beginning and end of the paragraph, and replace
-    line break sequences with a single line break"""
-    self._text = SrtParagraph._EOL_SEQ_RE.sub("\n", self._text).strip("\n\r")
+    line break sequences with a single line break. Lines that contain only
+    whitespace are treated as blank, so that whitespace-preserving input does not
+    emit an invalid blank line after the timing line."""
+    text = SrtParagraph._WS_LINE_RE.sub("", self._text)
+    self._text = SrtParagraph._EOL_SEQ_RE.sub("\n", text).strip("\n\r")
 
   def append_text(self, text: str):
     """Appends text to the paragraph"""

--- a/src/main/python/ttconv/vtt/cue.py
+++ b/src/main/python/ttconv/vtt/cue.py
@@ -49,6 +49,7 @@ class VttCue:
     right = "right"
 
   _EOL_SEQ_RE = re.compile(r"\n{2,}")
+  _WS_LINE_RE = re.compile(r"^[^\S\n]+$", re.MULTILINE)
 
   def __init__(self, identifier: Optional[int] = None):
     self._id: int = identifier
@@ -106,8 +107,11 @@ class VttCue:
 
   def normalize_eol(self):
     """Remove line breaks at the beginning and end of the paragraph, and replace
-    line break sequences with a single line break"""
-    self._text = VttCue._EOL_SEQ_RE.sub("\n", self._text).strip("\n\r")
+    line break sequences with a single line break. Lines that contain only
+    whitespace are treated as blank, so that whitespace-preserving input does not
+    emit an invalid blank line after the timing line."""
+    text = VttCue._WS_LINE_RE.sub("", self._text)
+    self._text = VttCue._EOL_SEQ_RE.sub("\n", text).strip("\n\r")
 
   def append_text(self, text: str):
     """Appends text to the paragraph"""

--- a/src/test/python/test_srt_writer.py
+++ b/src/test/python/test_srt_writer.py
@@ -37,6 +37,7 @@ import ttconv.imsc.reader as imsc_reader
 import ttconv.scc.reader as scc_reader
 import ttconv.srt.writer as srt_writer
 import ttconv.srt.config as srt_config
+from ttconv.srt.paragraph import SrtParagraph
 from ttconv.model import ContentDocument, Region, Body, Div, P, Span, Text, ContentElement
 from ttconv.style_properties import StyleProperties, DisplayType
 
@@ -103,6 +104,32 @@ Pellentesque interdum lacinia sollicitudin.
     srt_from_model = srt_writer.from_model(doc)
 
     self.assertEqual(expected_srt, srt_from_model)
+
+  def test_normalize_eol_whitespace_only_lines(self):
+    # Reproduces issue #350: with xml:space="preserve" the paragraph text
+    # contains whitespace-only lines around the content. These must be treated
+    # as blank so that the SRT output does not start with an invalid blank line
+    # right after the timing line.
+    paragraph = SrtParagraph(1)
+    paragraph.append_text("\n   \n   Test whitespace handling\n   \n   ")
+    paragraph.normalize_eol()
+
+    lines = paragraph._text.split("\n")
+    self.assertNotEqual(lines[0].strip(), "", msg="leading whitespace-only line was not removed")
+    self.assertNotEqual(lines[-1].strip(), "", msg="trailing whitespace-only line was not removed")
+    self.assertIn("Test whitespace handling", paragraph._text)
+
+    # An interior whitespace-only line must collapse to a single break, and
+    # already-clean text must be left untouched.
+    paragraph = SrtParagraph(1)
+    paragraph.append_text("Line one\n   \nLine two")
+    paragraph.normalize_eol()
+    self.assertEqual("Line one\nLine two", paragraph._text)
+
+    paragraph = SrtParagraph(1)
+    paragraph.append_text("Hello\nWorld")
+    paragraph.normalize_eol()
+    self.assertEqual("Hello\nWorld", paragraph._text)
 
   def test_scc_test_suite(self):
     for root, _subdirs, files in os.walk("src/test/resources/scc"):

--- a/src/test/python/test_vtt_writer.py
+++ b/src/test/python/test_vtt_writer.py
@@ -38,12 +38,39 @@ import ttconv.imsc.reader as imsc_reader
 import ttconv.scc.reader as scc_reader
 import ttconv.stl.reader as stl_reader
 from ttconv.vtt.config import VTTWriterConfiguration
+from ttconv.vtt.cue import VttCue
 import ttconv.vtt.writer as vtt_writer
 from ttconv.model import ContentDocument, Region, Body, Div, P, Span, Text, ContentElement
 from ttconv.style_properties import StyleProperties, DisplayType
 
 
 class VttWriterTest(unittest.TestCase):
+
+  def test_normalize_eol_whitespace_only_lines(self):
+    # Parity with the SRT writer fix for issue #350: with xml:space="preserve"
+    # the cue text contains whitespace-only lines around the content. These must
+    # be treated as blank so that the WebVTT output does not start with an
+    # invalid blank line right after the timing line.
+    cue = VttCue(1)
+    cue.append_text("\n   \n   Test whitespace handling\n   \n   ")
+    cue.normalize_eol()
+
+    lines = cue._text.split("\n")
+    self.assertNotEqual(lines[0].strip(), "", msg="leading whitespace-only line was not removed")
+    self.assertNotEqual(lines[-1].strip(), "", msg="trailing whitespace-only line was not removed")
+    self.assertIn("Test whitespace handling", cue._text)
+
+    # An interior whitespace-only line must collapse to a single break, and
+    # already-clean text must be left untouched.
+    cue = VttCue(1)
+    cue.append_text("Line one\n   \nLine two")
+    cue.normalize_eol()
+    self.assertEqual("Line one\nLine two", cue._text)
+
+    cue = VttCue(1)
+    cue.append_text("Hello\nWorld")
+    cue.normalize_eol()
+    self.assertEqual("Hello\nWorld", cue._text)
 
   def test_vtt_writer(self):
     doc = ContentDocument()


### PR DESCRIPTION
Fixes #350.

## Problem
Converting TTML/IMSC that uses `xml:space="preserve"` to SRT emits a whitespace-only line immediately after the timing line (which structurally terminates the cue, making the SRT invalid) plus trailing whitespace lines, exactly as reported in #350.

## Root cause
`SrtParagraph.normalize_eol()` collapses runs of pure `\n` (`_EOL_SEQ_RE = re.compile(r"\n{2,}")`) and strips only `\n`/`\r`. It does not treat a line containing only whitespace (spaces/tabs) as blank, so preserved whitespace-only lines survive collapsing and stripping and reach the output. The WebVTT writer (`vtt/cue.py`) carries the identical `normalize_eol`, kept in parity by #349, so it has the same defect. Note that #342/#349 are merged but did not fully fix this.

## Fix
Before the existing collapse+strip, blank out lines that consist only of whitespace, in both the SRT and WebVTT writers (kept in parity):

```python
_WS_LINE_RE = re.compile(r"^[^\S\n]+$", re.MULTILINE)
...
text = <Class>._WS_LINE_RE.sub("", self._text)
self._text = <Class>._EOL_SEQ_RE.sub("\n", text).strip("\n\r")
```

This reuses the existing collapse+strip (so all pre-existing behaviour for empty-line runs is unchanged) and preserves meaningful leading indentation on content lines (only fully-whitespace lines are affected).

Result for the reporter's input:

```srt
1
00:00:01,160 --> 00:00:03,160
            Test whitespace handling
```

**Semantic choice for review:** whitespace-only lines are dropped entirely rather than kept as a single blank line. This matches the writer's existing treatment of empty-line runs and is required because a blank line terminates a cue in both SRT and WebVTT. Happy to adjust if you'd prefer different handling.

## Tests
Added `test_normalize_eol_whitespace_only_lines` to both `test_srt_writer.py` and `test_vtt_writer.py`. Red/green confirmed: with the fix reverted the new assertion fails (`leading whitespace-only line was not removed`); with the fix it passes. Existing SRT/VTT writer tests still pass (the one pre-existing `test_empty_isds` error is from the `imsc-tests` submodule, unrelated).

AI-assisted: this change was prepared with AI assistance and reviewed by me.